### PR TITLE
Fb 48 create privacy page

### DIFF
--- a/apps/frontend/src/_components/Sidebar-Component/Navigation.tsx
+++ b/apps/frontend/src/_components/Sidebar-Component/Navigation.tsx
@@ -108,6 +108,11 @@ export const Navigation = ({
           <h1 className="hover:text-blue hover:cursor-pointer">Disclaimer</h1>
         </Link>
       </div>
+      <div className="flex flex-col md:flex-row lg:flex-row text-slate-400 text-sm space-x-2 justify-center items-center mt-0">
+        <Link href="/info/privacy">
+          <h1 className="hover:text-blue hover:cursor-pointer">Privacy</h1>
+        </Link>
+      </div>
     </div>
   );
 };

--- a/apps/frontend/src/app/info/privacy/page.tsx
+++ b/apps/frontend/src/app/info/privacy/page.tsx
@@ -26,8 +26,8 @@ export default function privacy() {
                 <ol className="list-[upper-alpha] list-inside">
                     <li className="text-base font-bold">Information that you provide</li>
                     <ul className="text-base list-disc list-inside">
-                       <li> Email Address </li>
-                       <li> Feedback or messages you send us</li> 
+                       <li> <span className="underline">Email Address</span> (e.g., when signing up or contacting us)</li>
+                       <li> <span className="underline">Feedback or messages</span> you send us</li> 
                     </ul>
                     
                     
@@ -81,7 +81,7 @@ export default function privacy() {
 
                 <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
                 <li>When We Share Information</li>
-                <p className="text-base">We do <span className="underlined">not share personal information</span> except:</p>
+                <p className="text-base">We do <span className="underline">not share personal information</span> except:</p>
                 <ul className="text-base list-disc list-inside">
                     <li>With trusted service providers (e.g., email or analytics platforms) who help us operate the platform</li>
                     <li>If required by law or legal process</li>
@@ -101,7 +101,7 @@ export default function privacy() {
                 
                 <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
                 <li>Children’s Privacy</li>
-                <p className="text-base">FinBud is not intended for children under the age of 13. We do not knowingly collect data from anyone under that age</p>
+                <p className="text-base">FinBud is not intended for children under the age of 13. We do not knowingly collect data from anyone under that age.</p>
                
                 <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
                 <li> Changes to This Policy</li>

--- a/apps/frontend/src/app/info/privacy/page.tsx
+++ b/apps/frontend/src/app/info/privacy/page.tsx
@@ -1,0 +1,131 @@
+export default function privacy() {
+  return (
+    <div className="flex-1 bg-light_blue_infoPage overflow-y-auto">
+      <div className="flex flex-col items-left h-screen mt-10 ml-10 mr-10 text-gray-50 dark:text-[#333]">
+        <h1 className="lg:text-4xl md:text-4xl text-3xl font-bold">FinBud Privacy Policy</h1>
+        <hr className="border-gray-50 dark:border-[#333] border-4 my-4" />
+        <p className="lg:text-lg md:text-lg sm:text-md text-sm">
+            <span className="underline">Effective Date:</span> May 31, 2025
+            
+
+        </p>
+
+        <br/>
+            FinBud (“we”, “our”, or “us”) is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and protect your personal information when you use our website, mobile app, and other services (“Services”).
+            <br/>
+            <hr className="border-gray-50 dark:border-[#333] border-2 my-4" />
+
+            <ol className="list-decimal list-inside lg:text-2xl md:text-4xl text-3xl font-bold">
+                <li >
+                    <span className="lg:text-2xl md:text-4xl text-3xl font-bold">What Information We Collect</span>
+                </li>
+                
+                <p className="text-base">We collect the following types of information:</p>
+                <br/>
+
+                <ol className="list-[upper-alpha] list-inside">
+                    <li className="text-base font-bold">Information that you provide</li>
+                    <ul className="text-base list-disc list-inside">
+                       <li> Email Address </li>
+                       <li> Feedback or messages you send us</li> 
+                    </ul>
+                    
+                    
+                    <p className="text-base">We do <span className="underline">not</span> collect sensitive personal financial data unless explicitly stated and consented to in the future.</p>
+
+                    <br/>
+                    <li className="text-base font-bold">Information Collected Automatically</li>
+                    <p className="text-base">We may collect limited non-personal information like:</p>
+                    
+                    <ul className="text-base list-disc list-inside">
+                        <li>Device type and browser</li>
+                        <li>IP address</li>
+                        <li>General usage data (e.g., which pages you visit)</li>
+                    </ul>
+
+                    <p className="text-base">This is used to improve performance and user experience.</p>
+                    
+
+                </ol>
+
+                <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
+               
+                <li>How We Use Your Information</li>
+                <p className="text-base">We use your information to:</p>
+                <ul className="text-base list-disc list-inside">
+                    <li>Operate and improve FinBud’s platform</li>
+                    <li>Respond to your messages or inquiries</li>
+                    <li>Send occasional updates (with your consent)</li>
+                    <li>Monitor performance and prevent abuse</li>
+                </ul>
+                <p className="text-base">We do <span className="underline">not sell or rent</span> your personal information.</p>
+
+                <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
+                <li>Cookies and Analytics</li>
+                <p className="text-base">We may use cookies and third-party analytics tools (e.g., Google Analytics) to:</p>
+                <ul className="text-base list-disc list-inside">
+                    <li>Track how users interact with our Services</li>
+                    <li>Measure engagement and improve functionality</li>
+                </ul>
+                <p className="text-base">You can control or disable cookies in your browser settings.</p>
+            
+                <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
+                <li>How We Protect Your Data</li>
+                <p className="text-base">We take reasonable precautions to protect your personal information, including:</p>
+                <ul className="text-base list-disc list-inside">
+                    <li>Limiting access to team members</li>
+                    <li>Using secure services and encryption where possible</li>
+                    <li>Not collecting more information than needed</li>
+                </ul>
+                <p className="text-base">However, no system is 100% secure. You use FinBud at your own risk.</p>
+
+                <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
+                <li>When We Share Information</li>
+                <p className="text-base">We do <span className="underlined">not share personal information</span> except:</p>
+                <ul className="text-base list-disc list-inside">
+                    <li>With trusted service providers (e.g., email or analytics platforms) who help us operate the platform</li>
+                    <li>If required by law or legal process</li>
+                </ul>
+                <p className="text-base">We will never share your info with advertisers or sell your data.</p>
+
+                <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
+                <li>Your Rights (Canadian Users)</li>
+                <p className="text-base">As a Canadian user, you have the right to:</p>
+                <ul className="text-base list-disc list-inside">
+                    <li>Access your personal data</li>
+                    <li>Correct inaccuracies</li>
+                    <li>Withdraw consent for future collection</li>
+                    <li>Request deletion (subject to legal limits)</li>
+                </ul>
+                <p className="text-base">To make a request, email us at <a className="text-base text-link_color hover:text-dark_blue" href="mailto:finbud.team@gmail.com">finbud.team@gmail.com</a>.</p>
+                
+                <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
+                <li>Children’s Privacy</li>
+                <p className="text-base">FinBud is not intended for children under the age of 13. We do not knowingly collect data from anyone under that age</p>
+               
+                <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
+                <li> Changes to This Policy</li>
+                <p className="text-base">We may update this Privacy Policy from time to time. We'll notify users of material changes by posting an updated policy and adjusting the “Effective Date” above.</p>
+
+                <hr className="border-gray-50 dark:border-[#333] border-2 my-4"/>
+                <li> Contact Us</li>
+                <p className="text-base">Have questions about this policy or your data?</p>
+                <a className="text-base text-link_color hover:text-dark_blue" href="mailto:finbud.team@gmail.com">finbud.team@gmail.com</a>
+              
+              
+
+            </ol>
+
+
+
+
+            <br/><br/><br/>
+            
+      </div>
+
+
+
+      
+    </div>
+  );
+}


### PR DESCRIPTION
## Describe your changes

- Added Privacy page with content in Drive. Same style as existing Disclaimer, About, and Contact Us pages.
- Added Privacy link in sidebar.
- Since default text is bolded, any bolded parts in the google doc, was underlined instead.

## Issue ticket number and link

Link: https://finbuddy.atlassian.net/jira/software/projects/FB/boards/1?selectedIssue=FB-48

## Verification of changes

Screenshots/Links:
![image](https://github.com/user-attachments/assets/26334560-c5e7-4122-bdc1-c9ade8ed66f1)
![image](https://github.com/user-attachments/assets/f645b332-cb82-4781-ad7e-0c45c5d81af9)
![image](https://github.com/user-attachments/assets/8308bd8c-8d4c-435b-9a97-96edeb5fa4b7)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested my code with current main branch
- [ ] If it is a core feature, I have added thorough tests.
- [ ] This will require an AWS Amplify update
